### PR TITLE
Update README.md

### DIFF
--- a/apps/accelerate/forward_forward/README.md
+++ b/apps/accelerate/forward_forward/README.md
@@ -36,7 +36,6 @@ import torch
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
-
 trained_model = train_with_forward_forward_algorithm(
     model_type="progressive",
     n_layers=3,


### PR DESCRIPTION
In this I added ```import os
import torch
device = "cuda" if torch.cuda.is_available() else "cpu"``` so that if someone is using m1 macOS then they do not have to worry about the errors that I previously got which include problems with torch vision and `ImportError: cannot import name 'COMMON_SAFE_ASCII_CHARACTERS' from 'charset_normalizer.constant'`